### PR TITLE
force canvas to use default font when empty string is passed

### DIFF
--- a/src/text.js
+++ b/src/text.js
@@ -8,7 +8,7 @@ S2D.CreateText = function(font, msg, size) {
   // Create image object
   var txt   = Object.create(S2D.Text);
   txt.color = Object.create(S2D.Color);
-  txt.font  = font;
+  txt.font  = font ? font : null;
   txt.msg   = msg;
   txt.size  = size;
   

--- a/test/testcard.html
+++ b/test/testcard.html
@@ -225,6 +225,7 @@ function render() {
   S2D.DrawText(txt_clr_r);
   S2D.DrawText(txt_clr_g);
   S2D.DrawText(txt_clr_b);
+  S2D.DrawText(default_font);
   
   // Window stats
   
@@ -325,6 +326,10 @@ txt_clr_b.color.r = 0.0;
 txt_clr_b.color.g = 0.0;
 txt_clr_b.color.b = 1.0;
 txt_clr_b.color.a = 1.0;
+
+var default_font = S2D.CreateText("", "Default font", font_size);
+default_font.x = 5;
+default_font.y = 270;
 
 var fps = S2D.CreateText(font, "FPS:", font_size);
 fps.x = 460;


### PR DESCRIPTION
Before this patch, if empty string was passed as font, the code did not throw any exception, but rendered the text in a miniature version, not is expected size, and completely unreadable. Setting font to null in such case forces browser to use whatever font it finds acceptable.